### PR TITLE
Fix: New keyword only for BrowserSettings fails on GitHub Actions

### DIFF
--- a/src/browserist/model/browser/base/settings.py
+++ b/src/browserist/model/browser/base/settings.py
@@ -6,7 +6,7 @@ from .page_load_strategy import PageLoadStrategy
 from .type import BrowserType
 
 
-@dataclass(slots=True)
+@dataclass(kw_only=True, slots=True)
 class BrowserSettings:
     """Class to configure the browser driver.
 


### PR DESCRIPTION
Revert "Revert "Ensure that browser settings are keyword only when created.""

This reverts commit b455b98fd31f5248b8dfe6809f928f4ee5187b71.