### PR TITLE
Feature: Ensure reliable encoding of single and double quotes in XPath expressions

### DIFF
--- a/src/browserist/helper/xpath.py
+++ b/src/browserist/helper/xpath.py
@@ -6,6 +6,20 @@ from lxml.etree import XPathSyntaxError
 from ..model.type.xpath import XPath
 
 
+def ensure_encoding_of_single_and_double_quotes(xpath: str) -> str:
+    """It's recommended to use only single quotes in XPath expressions. It that for some reason isn't the case, this helper converts double to single quotes and handles edge cases of apostrophes. Other functions, e.g. using JavaScript, may break if single and double quotes aren't reliable."""
+
+    def convert_double_to_single_quotes(xpath: str) -> str:
+        return xpath.replace("\"", "\'")
+
+    if "\"" in xpath:
+        if "\'" in xpath:  # If contains both single and double quotes.
+            # TODO: Handle strings with mixed single and double quotes.
+            return xpath
+        return convert_double_to_single_quotes(xpath)
+    return xpath
+
+
 def is_valid(xpath: str) -> bool:
     try:
         return bool(lxml.etree.XPath(xpath))

--- a/src/browserist/model/type/xpath.py
+++ b/src/browserist/model/type/xpath.py
@@ -16,7 +16,7 @@ class XPath(str):
     def __init__(self, xpath: str) -> None:
         if not helper.xpath.is_valid(xpath):
             raise XPathSyntaxError(xpath)
-        self.value: str = xpath
+        self.value: str = helper.xpath.ensure_encoding_of_single_and_double_quotes(xpath)
 
     def __str__(self) -> str:
         return self.value

--- a/test/helper/xpath/ensure_encoding_of_single_and_double_quote_test.py
+++ b/test/helper/xpath/ensure_encoding_of_single_and_double_quote_test.py
@@ -1,0 +1,15 @@
+import pytest
+from _mock_data.xpath.test_set_3 import VALID_XPATH
+
+from browserist import helper
+
+
+@pytest.mark.parametrize("xpath, expected_output", [
+    (VALID_XPATH, VALID_XPATH),
+    ("//button[contains(text(), \"Double Quotes\")]", "//button[contains(text(), 'Double Quotes')]"),
+    # TODO: Add test with mix of single and double quotes.
+])
+def test_ensure_encoding_of_single_and_double_quotes(xpath: str, expected_output: str) -> None:
+    assert helper.xpath.is_valid(xpath)
+    assert helper.xpath.is_valid(expected_output)
+    assert helper.xpath.ensure_encoding_of_single_and_double_quotes(xpath) == expected_output


### PR DESCRIPTION
It's recommended to use only single quotes in XPath expressions. It that for some reason isn't the case, this helper converts double to single quotes and handles edge cases of apostrophes. Other functions, e.g. using JavaScript, may break if single and double quotes aren't reliable.