### PR TITLE
Fix: Handle changed format in window IDs

### DIFF
--- a/src/browserist/helper/window_handle.py
+++ b/src/browserist/helper/window_handle.py
@@ -11,7 +11,7 @@ def id_already_exists(id: str, window_handles: list[WindowHandle]) -> bool:
     return id in [window_handle.id for window_handle in window_handles]
 
 
-WINDOW_HANDLE_ID_PATTERN = re.compile(r"^CDwindow-[A-Z0-9]{32}$")
+WINDOW_HANDLE_ID_PATTERN = re.compile(r"^(CDwindow-)?[A-Z0-9]{32}$")
 
 
 def is_valid_id(id: str) -> bool:


### PR DESCRIPTION
Fix issue in window ID check by making "CDwindow-" optional: "browserist.exception.window_handle.WindowHandleIdNotValidError: Window handle ID has invalid format: 6DD6E20AA523F24104FF1F878B778B4A"

<img width="1048" alt="Screenshot 2023-03-20 at 07 16 30" src="https://user-images.githubusercontent.com/25110864/226261790-f8005734-7489-4839-9f6e-6972bced5f6c.png">
