### PR TITLE
Refactor: Rename method "browser.prompt.prompt_proceed_yes_or_no()" to "browser.prompt.proceed_yes_or_no()"

### DIFF
--- a/src/browserist/browser/prompt/__main__.py
+++ b/src/browserist/browser/prompt/__main__.py
@@ -15,7 +15,7 @@ class PromptDriverMethods(DriverMethods):
             timeout = self._mediate_timeout(timeout)
             prompt_and_input_value(self._browser_driver, xpath, prompt_message, validate_input_regex, timeout)
 
-    def prompt_proceed_yes_or_no(self) -> bool:
+    def proceed_yes_or_no(self) -> bool:
         """Prompt user whether to proceed or not through the terminal."""
 
         if self._timeout_should_continue():

--- a/test/browser/prompt/proceed_yes_or_no_test.py
+++ b/test/browser/prompt/proceed_yes_or_no_test.py
@@ -13,4 +13,4 @@ from browserist import Browser
 def test_prompt_proceed_yes_or_no(user_input: str, expected: bool, browser_default_headless: Browser, monkeypatch: MonkeyPatch) -> None:
     browser = reset_to_not_timed_out(browser_default_headless)
     monkeypatch.setattr("builtins.input", lambda _: user_input)
-    assert browser.prompt.prompt_proceed_yes_or_no() is expected
+    assert browser.prompt.proceed_yes_or_no() is expected


### PR DESCRIPTION
It seems a little odd that we have a duplicate name in this method...

```python
browser.prompt.prompt_proceed_yes_or_no()
```

... so let's rename it to make it more consistent:

```python
browser.prompt.proceed_yes_or_no()
```