### PR TITLE
Fix: Migrate deprecated executable path to Service object

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 chromedriver==109.0.5414.74
 lxml==4.9.2
 pillow==9.5.0
-selenium==4.9.1
+selenium==4.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,12 +35,12 @@ python_requires = >=3.10
 setup_requires =
     lxml==4.9.2
     pillow==9.5.0
-    selenium==4.9.1
+    selenium==4.10.0
 install_requires =
     chromedriver
     lxml==4.9.2
     pillow==9.5.0
-    selenium==4.9.1
+    selenium==4.10.0
 zip_safe = no
 include_package_data = True
 

--- a/src/browserist/browser/wait/for_element.py
+++ b/src/browserist/browser/wait/for_element.py
@@ -17,7 +17,7 @@ def wait_for_element(browser_driver: BrowserDriver, xpath: str, timeout: float) 
         return
     try:
         driver = browser_driver.get_webdriver()
-        WebDriverWait(driver, timeout).until(EC.presence_of_element_located((By.XPATH, xpath)))  # type: ignore
+        WebDriverWait(driver, timeout).until(EC.presence_of_element_located((By.XPATH, xpath)))
     except TimeoutException:
         browser_driver.settings = set_is_timed_out(browser_driver.settings)
         if not should_continue(browser_driver.settings):

--- a/src/browserist/browser/wait/until/number_of_window_handles_is.py
+++ b/src/browserist/browser/wait/until/number_of_window_handles_is.py
@@ -12,7 +12,7 @@ def wait_until_number_of_window_handles_is(browser_driver: BrowserDriver, expect
         raise ValueError("Expected handles must be greater than or equal to 0.")
     try:
         driver = browser_driver.get_webdriver()
-        WebDriverWait(driver, timeout).until(EC.number_of_windows_to_be(expected_handles))  # type: ignore
+        WebDriverWait(driver, timeout).until(EC.number_of_windows_to_be(expected_handles))
     except TimeoutException:
         browser_driver.settings = set_is_timed_out(browser_driver.settings)
         if not should_continue(browser_driver.settings):

--- a/src/browserist/model/browser/base/driver.py
+++ b/src/browserist/model/browser/base/driver.py
@@ -1,10 +1,16 @@
 from abc import ABC, abstractmethod
 
 from selenium.webdriver.chrome.options import Options as ChromeOptions
+from selenium.webdriver.chrome.service import Service as ChromeService
+from selenium.webdriver.common.service import Service
 from selenium.webdriver.edge.options import Options as EdgeOptions
+from selenium.webdriver.edge.service import Service as EdgeService
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
+from selenium.webdriver.firefox.service import Service as FirefoxService
 from selenium.webdriver.ie.options import Options as IEOptions
+from selenium.webdriver.ie.service import Service as IEService
 from selenium.webdriver.safari.options import Options as SafariOptions
+from selenium.webdriver.safari.service import Service as SafariService
 
 from .... import helper
 from .settings import BrowserSettings
@@ -14,8 +20,7 @@ from .type import BrowserType
 class BrowserDriver(ABC):
     """Abstract class that contains the Selenium web driver based on browser type and configuration."""
 
-    __slots__ = ["settings", "chrome_options", "edge_options", "firefox_options",
-                 "ie_options", "safari_options", "webdriver"]
+    __slots__ = ["settings", "chrome_options", "chrome_service", "edge_options", "edge_service", "firefox_options", "firefox_service", "ie_options", "ie_service", "safari_options", "safari_service", "webdriver"]
 
     def __init__(self, settings: BrowserSettings) -> None:
         """Initiates basic properties of the Selenium web driver."""
@@ -26,14 +31,19 @@ class BrowserDriver(ABC):
         match(self.settings.type):
             case BrowserType.CHROME | BrowserType.OPERA:
                 self.chrome_options: ChromeOptions = ChromeOptions()
+                self.chrome_service: ChromeService = self.set_service()  # type: ignore
             case BrowserType.EDGE:
                 self.edge_options: EdgeOptions = EdgeOptions()
+                self.edge_service: EdgeService = self.set_service()  # type: ignore
             case BrowserType.FIREFOX:
                 self.firefox_options: FirefoxOptions = FirefoxOptions()
+                self.firefox_service: FirefoxService = self.set_service()  # type: ignore
             case BrowserType.INTERNET_EXPLORER:
                 self.ie_options: IEOptions = IEOptions()
+                self.ie_service: IEService = self.set_service()  # type: ignore
             case BrowserType.SAFARI:
                 self.safari_options: SafariOptions = SafariOptions()
+                self.safari_service: SafariService = self.set_service()  # type: ignore
 
         self.ensure_browser_type()
         self.set_options_and_profile()
@@ -73,6 +83,12 @@ class BrowserDriver(ABC):
     @abstractmethod
     def set_page_load_strategy(self) -> None:
         """Method to set the page load strategy to define whether the web driver should wait until all assets are downloaded (slower) or not (faster)."""
+
+        raise NotImplementedError  # pragma: no cover
+
+    @abstractmethod
+    def set_service(self) -> Service:
+        """Method to set the service."""
 
         raise NotImplementedError  # pragma: no cover
 

--- a/src/browserist/model/browser/chrome.py
+++ b/src/browserist/model/browser/chrome.py
@@ -1,4 +1,5 @@
 from selenium import webdriver
+from selenium.webdriver.chrome.service import Service as ChromeService
 
 from ... import factory
 from .base.driver import BrowserDriver
@@ -10,13 +11,9 @@ class ChromeBrowserDriver(BrowserDriver):
         self.settings.type = BrowserType.CHROME
 
     def set_webdriver(self) -> object:
-        if self.settings._path_to_executable is None:
-            return webdriver.Chrome(
-                options=self.chrome_options)
-        else:
-            return webdriver.Chrome(
-                executable_path=self.settings._path_to_executable,
-                options=self.chrome_options)
+        return webdriver.Chrome(
+            service=self.chrome_service,
+            options=self.chrome_options)
 
     def disable_images(self) -> None:
         self = factory.chromium.disable_images(self)  # type: ignore
@@ -26,3 +23,9 @@ class ChromeBrowserDriver(BrowserDriver):
 
     def set_page_load_strategy(self) -> None:
         self.chrome_options = factory.set.page_load_strategy(self, self.chrome_options)  # type: ignore
+
+    def set_service(self) -> ChromeService:
+        if self.settings._path_to_executable is None:
+            return ChromeService()
+        else:
+            return ChromeService(executable_path=self.settings._path_to_executable)

--- a/src/browserist/model/browser/edge.py
+++ b/src/browserist/model/browser/edge.py
@@ -1,4 +1,5 @@
 from selenium import webdriver
+from selenium.webdriver.edge.service import Service as EdgeService
 
 from ... import factory
 from .base.driver import BrowserDriver
@@ -10,13 +11,9 @@ class EdgeBrowserDriver(BrowserDriver):
         self.settings.type = BrowserType.EDGE
 
     def set_webdriver(self) -> object:
-        if self.settings._path_to_executable is None:
-            return webdriver.Edge(
-                options=self.edge_options)
-        else:
-            return webdriver.Edge(
-                executable_path=self.settings._path_to_executable,
-                options=self.edge_options)
+        return webdriver.Edge(
+            service=self.edge_service,
+            options=self.edge_options)
 
     def disable_images(self) -> None:
         if self.settings.disable_images:
@@ -33,3 +30,9 @@ class EdgeBrowserDriver(BrowserDriver):
 
     def set_page_load_strategy(self) -> None:
         self.edge_options = factory.set.page_load_strategy(self, self.edge_options)  # type: ignore
+
+    def set_service(self) -> EdgeService:
+        if self.settings._path_to_executable is None:
+            return EdgeService()
+        else:
+            return EdgeService(executable_path=self.settings._path_to_executable)

--- a/src/browserist/model/browser/firefox.py
+++ b/src/browserist/model/browser/firefox.py
@@ -1,4 +1,5 @@
 from selenium import webdriver
+from selenium.webdriver.firefox.service import Service as FirefoxService
 
 from ... import factory
 from .base.driver import BrowserDriver
@@ -10,13 +11,9 @@ class FirefoxBrowserDriver(BrowserDriver):
         self.settings.type = BrowserType.FIREFOX
 
     def set_webdriver(self) -> object:
-        if self.settings._path_to_executable is None:
-            return webdriver.Firefox(
-                options=self.firefox_options)
-        else:
-            return webdriver.Firefox(
-                executable_path=self.settings._path_to_executable,
-                options=self.firefox_options)
+        return webdriver.Firefox(
+            service=self.firefox_service,
+            options=self.firefox_options)
 
     def disable_images(self) -> None:
         if self.settings.disable_images:
@@ -29,3 +26,9 @@ class FirefoxBrowserDriver(BrowserDriver):
 
     def set_page_load_strategy(self) -> None:
         self.firefox_options = factory.set.page_load_strategy(self, self.firefox_options)  # type: ignore
+
+    def set_service(self) -> FirefoxService:
+        if self.settings._path_to_executable is None:
+            return FirefoxService()
+        else:
+            return FirefoxService(executable_path=self.settings._path_to_executable)

--- a/src/browserist/model/browser/internet_explorer.py
+++ b/src/browserist/model/browser/internet_explorer.py
@@ -1,4 +1,5 @@
 from selenium import webdriver
+from selenium.webdriver.ie.service import Service as IEService
 
 from ... import factory
 from ...exception.headless import HeadlessNotSupportedException
@@ -11,13 +12,9 @@ class InternetExplorerBrowserDriver(BrowserDriver):
         self.settings.type = BrowserType.INTERNET_EXPLORER
 
     def set_webdriver(self) -> object:
-        if self.settings._path_to_executable is None:
-            return webdriver.Ie(
-                options=self.ie_options)
-        else:
-            return webdriver.Ie(
-                executable_path=self.settings._path_to_executable,
-                options=self.ie_options)
+        return webdriver.Ie(
+            service=self.ie_service,
+            options=self.ie_options)
 
     def disable_images(self) -> None:
         factory.internet_explorer.disable_images(self)
@@ -27,3 +24,9 @@ class InternetExplorerBrowserDriver(BrowserDriver):
 
     def set_page_load_strategy(self) -> None:
         self.ie_options = factory.set.page_load_strategy(self, self.ie_options)  # type: ignore
+
+    def set_service(self) -> IEService:
+        if self.settings._path_to_executable is None:
+            return IEService()
+        else:
+            return IEService(executable_path=self.settings._path_to_executable)

--- a/src/browserist/model/browser/opera.py
+++ b/src/browserist/model/browser/opera.py
@@ -1,4 +1,5 @@
 from selenium import webdriver
+from selenium.webdriver.chrome.service import Service as ChromeService
 
 from ... import factory
 from .base.driver import BrowserDriver
@@ -10,13 +11,9 @@ class OperaBrowserDriver(BrowserDriver):
         self.settings.type = BrowserType.OPERA
 
     def set_webdriver(self) -> object:
-        if self.settings._path_to_executable is None:
-            return webdriver.Opera(  # type: ignore
-                options=self.chrome_options)
-        else:
-            return webdriver.Opera(  # type: ignore
-                executable_path=self.settings._path_to_executable,
-                options=self.chrome_options)
+        return webdriver.Opera(  # type: ignore
+            service=self.chrome_service,
+            options=self.chrome_options)
 
     def disable_images(self) -> None:
         self = factory.chromium.disable_images(self)  # type: ignore
@@ -26,3 +23,9 @@ class OperaBrowserDriver(BrowserDriver):
 
     def set_page_load_strategy(self) -> None:
         self.chrome_options = factory.set.page_load_strategy(self, self.chrome_options)  # type: ignore
+
+    def set_service(self) -> ChromeService:
+        if self.settings._path_to_executable is None:
+            return ChromeService()
+        else:
+            return ChromeService(executable_path=self.settings._path_to_executable)

--- a/src/browserist/model/browser/safari.py
+++ b/src/browserist/model/browser/safari.py
@@ -1,4 +1,5 @@
 from selenium import webdriver
+from selenium.webdriver.safari.service import Service as SafariService
 
 from ... import factory
 from ...exception.headless import HeadlessNotSupportedException
@@ -11,13 +12,9 @@ class SafariBrowserDriver(BrowserDriver):
         self.settings.type = BrowserType.SAFARI
 
     def set_webdriver(self) -> object:
-        if self.settings._path_to_executable is None:
-            return webdriver.Safari(
-                options=self.safari_options)
-        else:
-            return webdriver.Safari(
-                executable_path=self.settings._path_to_executable,
-                options=self.safari_options)
+        return webdriver.Safari(
+            service=self.safari_service,
+            options=self.safari_options)
 
     def disable_images(self) -> None:
         factory.safari.disable_images(self)
@@ -27,3 +24,9 @@ class SafariBrowserDriver(BrowserDriver):
 
     def set_page_load_strategy(self) -> None:
         self.safari_options = factory.set.page_load_strategy(self, self.safari_options)  # type: ignore
+
+    def set_service(self) -> SafariService:
+        if self.settings._path_to_executable is None:
+            return SafariService()
+        else:
+            return SafariService(executable_path=self.settings._path_to_executable)


### PR DESCRIPTION
Reference:

* https://www.selenium.dev/documentation/webdriver/getting_started/upgrade_to_selenium_4/#executable_path-has-been-deprecated-please-pass-in-a-service-object