### PR TITLE
Fix: Missing images on documentation site on GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"


### PR DESCRIPTION
Reference: https://github.com/jakob-bagterp/colorist-for-python/pull/250