### PR TITLE
Fix: Await transient and preliminary temporary download files for Chrome

### DIFF
--- a/src/browserist/model/download/chrome.py
+++ b/src/browserist/model/download/chrome.py
@@ -15,6 +15,11 @@ class ChromeDownloadHandler(DownloadHandler):
     def _temporary_file_extension(self) -> str:
         return ".crdownload"
 
+    def _is_preliminary_temporary_file(self, file_name: str) -> bool:
+        """When Chrome starts a download, it may create a transient preliminary temporary file, for example `.com.google.Chrome.1a2b3c`, that evaporates quickly until a temporary file is created."""
+
+        return file_name.startswith(".com.google.Chrome") and helper.file.is_file(self._download_dir, file_name)
+
     def _is_temporary_file(self, file_name: str) -> bool:
         """When Chrome starts a download, it uses `.crdownload` as extension for temporary files.
 

--- a/src/browserist/model/download/edge.py
+++ b/src/browserist/model/download/edge.py
@@ -15,6 +15,11 @@ class EdgeDownloadHandler(DownloadHandler):
     def _temporary_file_extension(self) -> str:
         return ".crdownload"
 
+    def _is_preliminary_temporary_file(self, file_name: str) -> bool:
+        return False  # Not supported by Edge.
+
+        # TODO: To be verified.
+
     def _is_temporary_file(self, file_name: str) -> bool:
         """When Edge starts a download, it uses `.crdownload` as extension for temporary files.
 

--- a/src/browserist/model/download/firefox.py
+++ b/src/browserist/model/download/firefox.py
@@ -15,6 +15,11 @@ class FirefoxDownloadHandler(DownloadHandler):
     def _temporary_file_extension(self) -> str:
         return ".part"
 
+    def _is_preliminary_temporary_file(self, file_name: str) -> bool:
+        return False  # Not supported by Firefox.
+
+        # TODO: To be verified.
+
     def _is_temporary_file(self, file_name: str) -> bool:
         """When Firefox starts a download, it uses `.part` as extension for temporary files.
 

--- a/src/browserist/model/download/handler.py
+++ b/src/browserist/model/download/handler.py
@@ -80,9 +80,14 @@ class DownloadHandler(ABC):
     def _await_no_preliminary_temporary_files(self) -> None:
         """If the browser uses preliminary temporary files transiently before a temporary file is created, wait until any preliminary files has evaporated."""
 
+        def has_no_new_files_in_download_directory(download_dir_entries: list[str]) -> bool:
+            number_of_current_download_dir_entries = len(download_dir_entries)
+            number_of_download_dir_entries_before_download = len(self._download_dir_entries_before_download)
+            return number_of_current_download_dir_entries <= number_of_download_dir_entries_before_download
+
         def has_any_new_preliminary_temporary_files() -> bool:
             download_dir_entries = get_directory_entries(self._download_dir)
-            if len(download_dir_entries) == len(self._download_dir_entries_before_download):
+            if has_no_new_files_in_download_directory(download_dir_entries):
                 return False
             download_dir_entries_difference = [file for file in download_dir_entries if file not in self._download_dir_entries_before_download]
             return any(self._is_preliminary_temporary_file(file) for file in download_dir_entries_difference)

--- a/src/browserist/model/download/internet_explorer.py
+++ b/src/browserist/model/download/internet_explorer.py
@@ -19,6 +19,11 @@ class InternetExplorerDownloadHandler(DownloadHandler):
 
         # TODO: To be verified.
 
+    def _is_preliminary_temporary_file(self, file_name: str) -> bool:
+        return False  # Not supported by Internet Explorer.
+
+        # TODO: To be verified.
+
     def _is_temporary_file(self, file_name: str) -> bool:
         """TODO: To be verified."""
 

--- a/src/browserist/model/download/safari.py
+++ b/src/browserist/model/download/safari.py
@@ -15,6 +15,11 @@ class SafariDownloadHandler(DownloadHandler):
     def _temporary_file_extension(self) -> str:
         return ".download"
 
+    def _is_preliminary_temporary_file(self, file_name: str) -> bool:
+        return False  # Not supported by Safari.
+
+        # TODO: To be verified.
+
     def _is_temporary_file(self, file_name: str) -> bool:
         """When Safari starts a download, it uses `.download` as extension for temporary files.
 


### PR DESCRIPTION
Various issues identified during downloads that make the download methods unstable:

<img width="1019" alt="Screenshot 2023-12-28 at 13 33 37" src="https://github.com/jakob-bagterp/browserist/assets/25110864/f36e11f6-c9b7-41a2-9ad5-a092df5a2aa3">

<img width="1026" alt="Screenshot 2023-12-28 at 13 34 25" src="https://github.com/jakob-bagterp/browserist/assets/25110864/5f63447f-edbc-46ff-8079-3fa4c3c2e4f5">
