### PR TITLE
Fix: Pytest issue in set timeout for Python 3.10  for Windows and roll back Selenium from 4.27.1 to 4.26.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ chromedriver==109.0.5414.74
 lxml==5.3.0
 pillow==11.0.0
 requests==2.32.3
-selenium==4.27.1
+selenium==4.26.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,13 +43,13 @@ setup_requires =
     lxml==5.3.0
     pillow==11.0.0
     requests==2.32.3
-    selenium==4.27.1
+    selenium==4.26.1
 install_requires =
     chromedriver
     lxml==5.3.0
     pillow==11.0.0
     requests==2.32.3
-    selenium==4.27.1
+    selenium==4.26.1
 zip_safe = no
 include_package_data = True
 


### PR DESCRIPTION
<img width="1394" alt="Screenshot 2024-12-04 at 19 48 59" src="https://github.com/user-attachments/assets/2be292e5-40d4-4195-8afa-b58d0c0481a5">
