### PR TITLE
Fix: Remove support for Python 3.10 due to issues with Selenium 4.27.1 or later versions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
           lfs: true
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/docs_version_control.yml
+++ b/.github/workflows/docs_version_control.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Set release notes tag
         run: |
             export RELEASE_TAG_VERSION=${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install build tools
         run: |
@@ -144,7 +144,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Wait for PyPI to update
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - --py310-plus
+          - --py311-plus
 
 ci:
   autofix_prs: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,5 +67,5 @@ ci:
   autofix_prs: true
   autoupdate_schedule: quarterly
   submodules: false
-  # TODO: Temporarily ignored hooks since the CI checker doesn't use Python 3.8 and not 3.10, which gives syntax errors.
+  # TODO: Temporarily ignored hooks since the CI checker doesn't use Python 3.8 and not 3.11, which gives syntax errors.
   skip: [check-ast, check-docstring-first, debug-statements, flake8]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Latest version](https://img.shields.io/static/v1?label=version&message=1.6.24&color=yellowgreen)](https://github.com/jakob-bagterp/browserist/releases/latest)
-[![Python 3.10 | 3.11 | 3.12 | 3.13+](https://img.shields.io/static/v1?label=python&message=3.10%20|%203.11%20|%203.12%20|%203.13%2B&color=blueviolet)](https://www.python.org)
+[![Python 3.11 | 3.12 | 3.13+](https://img.shields.io/static/v1?label=python&message=3.11%20|%203.12%20|%203.13%2B&color=blueviolet)](https://www.python.org)
 [![Apache 2.0 license](https://img.shields.io/static/v1?label=license&message=Apache%202.0&color=blue)](https://github.com/jakob-bagterp/browserist/blob/master/LICENSE.md)
 [![Codecov](https://codecov.io/gh/jakob-bagterp/browserist/branch/master/graph/badge.svg?token=1JL65T099J)](https://codecov.io/gh/jakob-bagterp/browserist)
 [![CodeQL](https://github.com/jakob-bagterp/browserist/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/jakob-bagterp/browserist/actions/workflows/github-code-scanning/codeql)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,7 +12,7 @@ tags:
 ## Prerequisites
 In order to run Browserist successfully, you need to have the following installed:
 
-* [Python 3.10 or higher](https://www.python.org)
+* [Python 3.11 or higher](https://www.python.org)
 * [Relevant browser and driver](recommended-drivers.md)
 
 !!! info

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ description: Browserist is the easy way to do web scraping and browser automatio
 ---
 
 [![Latest version](https://img.shields.io/static/v1?label=version&message=1.6.24&color=yellowgreen)](https://github.com/jakob-bagterp/browserist/releases/latest)
-[![Python 3.10 | 3.11 | 3.12 | 3.13+](https://img.shields.io/static/v1?label=python&message=3.10%20|%203.11%20|%203.12%20|%203.13%2B&color=blueviolet)](https://www.python.org)
+[![Python 3.11 | 3.12 | 3.13+](https://img.shields.io/static/v1?label=python&message=3.11%20|%203.12%20|%203.13%2B&color=blueviolet)](https://www.python.org)
 [![Apache 2.0 license](https://img.shields.io/static/v1?label=license&message=Apache%202.0&color=blue)](https://github.com/jakob-bagterp/browserist/blob/master/LICENSE.md)
 [![Codecov](https://codecov.io/gh/jakob-bagterp/browserist/branch/master/graph/badge.svg?token=1JL65T099J)](https://codecov.io/gh/jakob-bagterp/browserist)
 [![CodeQL](https://github.com/jakob-bagterp/browserist/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/jakob-bagterp/browserist/actions/workflows/github-code-scanning/codeql)

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ platforms = unix, linux, osx, cygwin, win32
 classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
@@ -38,7 +37,7 @@ license_files = LICENSE.md
 package_dir =
     = src
 packages = find:
-python_requires = >=3.10
+python_requires = >=3.11
 setup_requires =
     lxml==5.3.0
     pillow==11.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.8.0
-envlist = py310, mypy, flake8
+envlist = py311, mypy, flake8
 isolated_build = true
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ isolated_build = true
 
 [gh-actions]
 python =
-    3.10: py310, mypy, flake8
+    3.11: py311, mypy, flake8
 
 [testenv]
 setenv =
@@ -52,14 +52,14 @@ commands =
         --ignore=test/type/xpath/exception_handling/method/wait_until_images_have_loaded_test.py
 
 [testenv:mypy]
-basepython = python3.10
+basepython = python3.11
 deps =
     -r{toxinidir}/requirements_dev.txt
     types-requests
 commands = mypy --install-types --non-interactive src
 
 [testenv:flake8]
-basepython = python3.10
+basepython = python3.11
 deps = flake8
 commands = flake8 src test
 


### PR DESCRIPTION
Tests in GitHub Actions fail when running Python 3.10 on Windows with Selenium 4.27.1 or later versions. Python 3.11 or later works fine.

Related issues:

* #761
* #778

<img width="1111" alt="Screenshot 2025-01-27 at 20 11 24" src="https://github.com/user-attachments/assets/afc99cfe-bb22-4560-b590-8231f8dd066a" />