### PR TITLE
Fix: MkDocs deployment issue due to ModuleNotFoundError

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,4 +26,5 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: pip install -r ./docs/requirements.txt
+      - run: pip install .
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
<img width="1217" alt="Screenshot 2025-02-10 at 12 38 11" src="https://github.com/user-attachments/assets/a1c4c59d-2bde-4134-b5c7-53f5dc687a09" />

Similar issue observed and fixed in this PR:

* #786