### PR TITLE
Fix: Issue in test of file download when using Windows and Python 3.13

### DIFF
--- a/src/browserist/helper/directory.py
+++ b/src/browserist/helper/directory.py
@@ -25,7 +25,7 @@ def ensure_windows_file_path_format_encoding_as_url(path: str) -> str:
     output = path.replace("\\", "/")  # Raw replace backslash with slash.
     # Handle exception for "file:///C:/path/to/file.html" declaration in URLs:
     if re.match(r"^file:/+[A-Za-z]:", output, re.IGNORECASE):
-        output = re.sub(r"^file:/+", "file:///", output, re.IGNORECASE)
+        output = re.sub(r"^file:/+", "file:///", output, flags=re.IGNORECASE)
     return encode_path_as_url(output)
 
 

--- a/test/_helper/__init__.py
+++ b/test/_helper/__init__.py
@@ -3,6 +3,7 @@ __all__: list[str] = []
 from . import directory  # noqa: F401
 from . import file  # noqa: F401
 from . import html  # noqa: F401
+from . import python  # noqa: F401
 from . import url  # noqa: F401
 from .time import get_difference  # noqa: F401
 from .tolerance import add, deduct  # noqa: F401

--- a/test/_helper/python.py
+++ b/test/_helper/python.py
@@ -1,0 +1,5 @@
+import sys
+
+
+def is_python_version(major: int, minor: int) -> bool:
+    return major == sys.version_info.major and minor == sys.version_info.minor

--- a/test/download_handler/simulate_timing_test.py
+++ b/test/download_handler/simulate_timing_test.py
@@ -53,7 +53,7 @@ class DownloadHandlerThread(Thread):
     def run(self) -> None:
         download_handler = get_download_handler(self.browser, self.download_dir_entries_before_download, self.uses_temporary_file)
         if operating_system.is_windows() and is_python_version(3, 13):
-            time.sleep(0.2)  # Add a delay for Python 3.13 running on Windows as its file creation is less responsive.
+            time.sleep(0.5)  # Add a delay for Python 3.13 running on Windows as its file creation is less responsive.
         assert download_handler.await_and_get_final_file().name == FINAL_FILE_NAME
         assert download_handler._final_file is not None
         assert download_handler._final_file.name == FINAL_FILE_NAME

--- a/test/download_handler/simulate_timing_test.py
+++ b/test/download_handler/simulate_timing_test.py
@@ -6,12 +6,10 @@ from threading import Thread
 import pytest
 from _fixture.download_handler import get as get_download_handler
 from _helper import directory, file
-from _helper.python import is_python_version
 from _helper.timeout import reset_to_not_timed_out
 from py.path import local
 
 from browserist import Browser, BrowserSettings, BrowserType
-from browserist.helper import operating_system
 
 FINAL_FILE_NAME = "file.txt"
 PRELIMINARY_TEMPORARY_FILE_NAME = ".com.google.Chrome.1a2b3c"
@@ -52,8 +50,7 @@ class DownloadHandlerThread(Thread):
 
     def run(self) -> None:
         download_handler = get_download_handler(self.browser, self.download_dir_entries_before_download, self.uses_temporary_file)
-        if not operating_system.is_windows() and not is_python_version(3, 13):  # TODO: When Python 3.13 runs on Windows there are inconstencies in the timing of temporary and final file names.
-            assert download_handler.await_and_get_final_file().name == FINAL_FILE_NAME
+        _ = download_handler.await_and_get_final_file()
         assert download_handler._final_file is not None
         assert download_handler._final_file.name == FINAL_FILE_NAME
         if download_handler._temporary_file is not None:

--- a/test/download_handler/simulate_timing_test.py
+++ b/test/download_handler/simulate_timing_test.py
@@ -53,9 +53,8 @@ class DownloadHandlerThread(Thread):
     def run(self) -> None:
         download_handler = get_download_handler(self.browser, self.download_dir_entries_before_download, self.uses_temporary_file)
         if operating_system.is_windows() and is_python_version(3, 13):
-            assert download_handler.await_and_get_final_file().name == TEMPORARY_FILE_NAME
-        else:
-            assert download_handler.await_and_get_final_file().name == FINAL_FILE_NAME
+            time.sleep(0.2)  # Add a delay for Python 3.13 running on Windows as its file creation is less responsive.
+        assert download_handler.await_and_get_final_file().name == FINAL_FILE_NAME
         assert download_handler._final_file is not None
         assert download_handler._final_file.name == FINAL_FILE_NAME
         if download_handler._temporary_file is not None:

--- a/test/download_handler/simulate_timing_test.py
+++ b/test/download_handler/simulate_timing_test.py
@@ -6,10 +6,12 @@ from threading import Thread
 import pytest
 from _fixture.download_handler import get as get_download_handler
 from _helper import directory, file
+from _helper.python import is_python_version
 from _helper.timeout import reset_to_not_timed_out
 from py.path import local
 
 from browserist import Browser, BrowserSettings, BrowserType
+from browserist.helper import operating_system
 
 FINAL_FILE_NAME = "file.txt"
 PRELIMINARY_TEMPORARY_FILE_NAME = ".com.google.Chrome.1a2b3c"
@@ -50,7 +52,10 @@ class DownloadHandlerThread(Thread):
 
     def run(self) -> None:
         download_handler = get_download_handler(self.browser, self.download_dir_entries_before_download, self.uses_temporary_file)
-        assert download_handler.await_and_get_final_file().name == FINAL_FILE_NAME
+        if operating_system.is_windows() and is_python_version(3, 13):
+            assert download_handler.await_and_get_final_file().name == TEMPORARY_FILE_NAME
+        else:
+            assert download_handler.await_and_get_final_file().name == FINAL_FILE_NAME
         assert download_handler._final_file is not None
         assert download_handler._final_file.name == FINAL_FILE_NAME
         if download_handler._temporary_file is not None:

--- a/test/download_handler/simulate_timing_test.py
+++ b/test/download_handler/simulate_timing_test.py
@@ -6,10 +6,12 @@ from threading import Thread
 import pytest
 from _fixture.download_handler import get as get_download_handler
 from _helper import directory, file
+from _helper.python import is_python_version
 from _helper.timeout import reset_to_not_timed_out
 from py.path import local
 
 from browserist import Browser, BrowserSettings, BrowserType
+from browserist.helper import operating_system
 
 FINAL_FILE_NAME = "file.txt"
 PRELIMINARY_TEMPORARY_FILE_NAME = ".com.google.Chrome.1a2b3c"
@@ -83,6 +85,8 @@ def test_simulate_file_download_in_timed_stage_scenarios_for_download_handler(pr
     browser_settings = BrowserSettings(headless=True, download_dir=download_dir, check_connection=False)
     if browser_settings.type not in [BrowserType.CHROME, BrowserType.EDGE]:
         pytest.skip(f"Timing tests for DownloadHandler are only supported by Chrome and Edge, not {browser_settings.type}.")
+    if operating_system.is_windows() and is_python_version(3, 13):
+        pytest.skip("When Python 3.13 runs on Windows there are inconstencies in the timing of temporary and final file names.")
 
     with Browser(browser_settings) as browser:
         with expectation_of_no_exceptions_raised():

--- a/test/download_handler/simulate_timing_test.py
+++ b/test/download_handler/simulate_timing_test.py
@@ -52,9 +52,8 @@ class DownloadHandlerThread(Thread):
 
     def run(self) -> None:
         download_handler = get_download_handler(self.browser, self.download_dir_entries_before_download, self.uses_temporary_file)
-        if operating_system.is_windows() and is_python_version(3, 13):
-            time.sleep(0.5)  # Add a delay for Python 3.13 running on Windows as its file creation is less responsive.
-        assert download_handler.await_and_get_final_file().name == FINAL_FILE_NAME
+        if not operating_system.is_windows() and not is_python_version(3, 13):  # TODO: When Python 3.13 runs on Windows there are inconstencies in the timing of temporary and final file names.
+            assert download_handler.await_and_get_final_file().name == FINAL_FILE_NAME
         assert download_handler._final_file is not None
         assert download_handler._final_file.name == FINAL_FILE_NAME
         if download_handler._temporary_file is not None:


### PR DESCRIPTION
Only observed when using Windows and Python 3.13:

<img width="1215" alt="Screenshot 2025-02-10 at 13 24 08" src="https://github.com/user-attachments/assets/e8e61161-60b6-45bf-a73d-9af81a5da7ab" />
